### PR TITLE
refactor: Refactor `visibility-entity-name.pipe:transform`

### DIFF
--- a/src/web/app/components/visibility-messages/visibility-entity-name.pipe.ts
+++ b/src/web/app/components/visibility-messages/visibility-entity-name.pipe.ts
@@ -28,41 +28,16 @@ export class VisibilityEntityNamePipe implements PipeTransform {
             customNumberOfEntitiesToGiveFeedbackTo?: number): string {
     switch (visibilityType) {
       case FeedbackVisibilityType.RECIPIENT: {
+        if (questionRecipientType === undefined)
+          return 'unknown';
         // get entity name
-        let recipientEntityName: string = '';
-        switch (questionRecipientType) {
-          case FeedbackParticipantType.INSTRUCTORS:
-            recipientEntityName = 'instructor';
-            break;
-          case FeedbackParticipantType.STUDENTS:
-          case FeedbackParticipantType.STUDENTS_EXCLUDING_SELF:
-          case FeedbackParticipantType.STUDENTS_IN_SAME_SECTION:
-          case FeedbackParticipantType.OWN_TEAM_MEMBERS:
-          case FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF:
-            recipientEntityName = 'student';
-            break;
-          case FeedbackParticipantType.TEAMS:
-          case FeedbackParticipantType.TEAMS_EXCLUDING_SELF:
-          case FeedbackParticipantType.TEAMS_IN_SAME_SECTION:
-          case FeedbackParticipantType.OWN_TEAM:
-            recipientEntityName = 'team';
-            break;
-          default:
-            return 'unknown';
-        }
-
-        if ([FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.STUDENTS,
-          FeedbackParticipantType.STUDENTS_EXCLUDING_SELF, FeedbackParticipantType.TEAMS,
-          FeedbackParticipantType.TEAMS_EXCLUDING_SELF]
-            .includes(questionRecipientType)) {
-          // if questionRecipientType is one of certain participant type, add the plural form
-          if (numberOfEntitiesToGiveFeedbackToSetting === NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED
-              || (numberOfEntitiesToGiveFeedbackToSetting === NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM
-                  && customNumberOfEntitiesToGiveFeedbackTo !== undefined
-                  && customNumberOfEntitiesToGiveFeedbackTo > 1)) {
-            recipientEntityName = `${recipientEntityName}s`;
-          }
-        }
+        let recipientEntityName: string = this.getEntityName(questionRecipientType);
+        
+        let plural: boolean = this.isPlural(questionRecipientType,  
+          numberOfEntitiesToGiveFeedbackToSetting,
+          customNumberOfEntitiesToGiveFeedbackTo);
+        if (plural)
+          recipientEntityName = `${recipientEntityName}s`;
 
         return `The receiving ${recipientEntityName}`;
       }
@@ -78,5 +53,57 @@ export class VisibilityEntityNamePipe implements PipeTransform {
         return 'Unknown';
     }
   }
+  
+  /**
+   * Converts a {@code FeedbackParticipantType} to string representation.
+   * 
+   * @param questionRecipientType
+   */
+  getEntityName(questionRecipientType: FeedbackParticipantType): string {
+    if (FeedbackParticipantType.INSTRUCTORS === questionRecipientType) {
+      return 'instructor';
+    }
+    else if ([FeedbackParticipantType.STUDENTS,
+        FeedbackParticipantType.STUDENTS_EXCLUDING_SELF,
+        FeedbackParticipantType.STUDENTS_IN_SAME_SECTION,
+        FeedbackParticipantType.OWN_TEAM_MEMBERS,
+        FeedbackParticipantType.OWN_TEAM_MEMBERS_INCLUDING_SELF]
+        .includes(questionRecipientType)) {
+      return 'student'
+    }
+    else if ([FeedbackParticipantType.TEAMS,
+        FeedbackParticipantType.TEAMS_EXCLUDING_SELF,
+        FeedbackParticipantType.TEAMS_IN_SAME_SECTION,
+        FeedbackParticipantType.OWN_TEAM]
+        .includes(questionRecipientType)) {
+      return 'team'
+    }
+    return '';
+  }
 
+  /**
+   * Checks if a recipient is plural for grammar purposes.
+   * 
+   * @param questionRecipientType 
+   * @param numberOfEntitiesToGiveFeedbackToSetting 
+   * @param customNumberOfEntitiesToGiveFeedbackTo 
+   * @returns true if plural, false if not
+   */
+  isPlural(questionRecipientType: FeedbackParticipantType,  
+           numberOfEntitiesToGiveFeedbackToSetting?: NumberOfEntitiesToGiveFeedbackToSetting,
+           customNumberOfEntitiesToGiveFeedbackTo?: number): boolean {
+    if ([FeedbackParticipantType.INSTRUCTORS, FeedbackParticipantType.STUDENTS,
+      FeedbackParticipantType.STUDENTS_EXCLUDING_SELF, FeedbackParticipantType.TEAMS,
+      FeedbackParticipantType.TEAMS_EXCLUDING_SELF]
+        .includes(questionRecipientType)) {
+      // if questionRecipientType is one of certain participant type, add the plural form
+      if (numberOfEntitiesToGiveFeedbackToSetting === NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED
+          || (numberOfEntitiesToGiveFeedbackToSetting === NumberOfEntitiesToGiveFeedbackToSetting.CUSTOM
+              && customNumberOfEntitiesToGiveFeedbackTo !== undefined
+              && customNumberOfEntitiesToGiveFeedbackTo > 1)) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
This closes #58, and is part of achieving P #7 point 3 and P+ #9 point 3.

#### Plan
* Break `switch (questionRecipientType)` on line 33 out into its own function `getEntityName()`
* Put the plural check in its own function `isPlural()`

This improves readability and makes it less spaghetti-like.

#### Complexity before refactor
```
{
transform: 14
}
```

#### Complexity after refactor
```
{
transform: 8,
getEntityName: 4,
isPlural: 6
}
```