### PR TITLE
feat: Add copy course button to single-course page

### DIFF
--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.html
@@ -68,6 +68,10 @@
                    ngbTooltip="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)"
                    (click)="archiveCourse(courseTabModel.course.courseId)"> Archive
                 </a>
+                <a id="btn-archive-course" class="btn btn-light btn-sm dropdown-item"
+                   ngbTooltip="Copy the course and its corresponding sessions"
+                   (click)="copyCourse(courseTabModel.course.courseId)"> Copy
+                </a>
                 <a class="btn btn-light btn-sm dropdown-item"
                    tmRouterLink='/web/instructor/courses/edit' [queryParams]="{courseid: courseTabModel.course.courseId}"> View / Edit
                 </a>

--- a/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
+++ b/src/web/app/pages-instructor/instructor-home-page/instructor-home-page.component.ts
@@ -209,6 +209,10 @@ export class InstructorHomePageComponent extends InstructorSessionModalPageCompo
         });
   }
 
+  copyCourse(courseId: string): void {
+    alert(`Course id ${courseId}`);
+  }
+
   /**
    * Loads the feedback session in the course and sorts them according to end date.
    */


### PR DESCRIPTION
Fixes #62 

Add "copy" button to single-course view too (was previously only visible from courses-view)